### PR TITLE
Fix message of /dxl dungeonItem false

### DIFF
--- a/src/main/java/de/erethon/dungeonsxl/command/DungeonItemCommand.java
+++ b/src/main/java/de/erethon/dungeonsxl/command/DungeonItemCommand.java
@@ -70,7 +70,7 @@ public class DungeonItemCommand extends DCommand {
                 NBTUtil.removeKey(tag, NBTUtil.DUNGEON_ITEM_KEY);
                 inv.setItemInHand(NBTUtil.setTag(bukkitStack, tag));
             }
-            MessageUtil.sendMessage(sender, DMessage.CMD_DUNGEON_ITEM_INFO_GLOBAL.getMessage());
+            MessageUtil.sendMessage(sender, DMessage.CMD_DUNGEON_ITEM_SET_GLOBAL.getMessage());
             MessageUtil.sendMessage(sender, DMessage.HELP_GLOBAL_ITEM.getMessage());
 
         } else {


### PR DESCRIPTION
After calling `/dxl dungeonItem false`
Message show to the player should be `CMD_DUNGEON_ITEM_SET_GLOBAL` instead of `CMD_DUNGEON_ITEM_INFO_GLOBAL`