### PR TITLE
Fixes broken teleport sign

### DIFF
--- a/core/src/main/java/de/erethon/dungeonsxl/sign/button/TeleportSign.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/sign/button/TeleportSign.java
@@ -75,13 +75,11 @@ public class TeleportSign extends Button implements LocationSign {
 
     @Override
     public boolean validate() {
-        for (int i = 1; i <= 2; i++) {
+        for (int i = 1; i <= 2; i++) {            
             if (!getLine(i).isEmpty()) {
-                if (BlockUtil.lettersToYaw(getLine(i)) == -1) {
-                    String[] loc = getLine(i).split(",");
-                    if (loc.length != 3) {
-                        return false;
-                    }
+                String[] loc = getLine(i).split(",");
+                if (loc.length != 3) {
+                    return false;    
                 }
             }
         }


### PR DESCRIPTION
There is something wrong with the `BlockUtil.lettersToYaw(getLine(i)` ; was raising an error about the onSignChange event being null.

Tried to investigate but I guess it's a compiled dependency of the plugin.

Apparently removing it completely fixes the issue.

**How to reproduce**

- Create a teleport sign

[Teleport]
1,2,3

D 2

...error on the console

[Teleport] alone 'works' but i'd expect some argument for this sign


**Paper 1.15.2**