### PR TITLE
Announce command

### DIFF
--- a/core/src/main/java/de/erethon/dungeonsxl/announcer/AnnouncerCache.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/announcer/AnnouncerCache.java
@@ -46,7 +46,7 @@ public class AnnouncerCache {
         for (File file : folder.listFiles()) {
             addAnnouncer(new Announcer(plugin, file));
         }
-        if (!announcers.isEmpty()) {
+        if (!announcers.isEmpty() && plugin.getMainConfig().getAnnouncmentInterval() > 0) {
             new AnnouncerTask(plugin).runTaskTimer(plugin, plugin.getMainConfig().getAnnouncmentInterval(), plugin.getMainConfig().getAnnouncmentInterval());
         }
         Bukkit.getPluginManager().registerEvents(new AnnouncerListener(plugin), plugin);

--- a/core/src/main/java/de/erethon/dungeonsxl/announcer/AnnouncerStartGameTask.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/announcer/AnnouncerStartGameTask.java
@@ -76,6 +76,8 @@ public class AnnouncerStartGameTask extends BukkitRunnable {
                 continue;
             }
 
+            dGroup.setDungeon(announcer.getDungeonName() == null ? announcer.getMapName() : announcer.getDungeonName());
+
             if (game == null) {
                 ResourceWorld resource = plugin.getMapRegistry().get(announcer.getMapName());
                 if (resource == null) {
@@ -94,7 +96,6 @@ public class AnnouncerStartGameTask extends BukkitRunnable {
                 game.addGroup(dGroup);
             }
 
-            dGroup.setDungeon(announcer.getDungeonName() == null ? announcer.getMapName() : announcer.getDungeonName());
             dGroup.setGameWorld(game.getWorld());
         }
 

--- a/core/src/main/java/de/erethon/dungeonsxl/announcer/AnnouncerTask.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/announcer/AnnouncerTask.java
@@ -17,11 +17,10 @@
 package de.erethon.dungeonsxl.announcer;
 
 import de.erethon.dungeonsxl.DungeonsXL;
+import de.erethon.dungeonsxl.api.player.GlobalPlayer;
+import de.erethon.dungeonsxl.api.player.InstancePlayer;
 import de.erethon.dungeonsxl.player.DGlobalPlayer;
-import de.erethon.dungeonsxl.player.DInstancePlayer;
 import java.util.List;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 /**
@@ -45,11 +44,10 @@ public class AnnouncerTask extends BukkitRunnable {
     public void run() {
         Announcer announcer = announcers.get(index);
         List<String> worlds = announcer.getWorlds();
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            DGlobalPlayer dPlayer = (DGlobalPlayer) plugin.getPlayerCache().get(player);
-            if (!(dPlayer instanceof DInstancePlayer) && dPlayer.isAnnouncerEnabled()) {
-                if (worlds.isEmpty() || worlds.contains(player.getWorld().getName())) {
-                    announcer.send(player);
+        for (GlobalPlayer dPlayer : plugin.getPlayerCache()) {
+            if (!(dPlayer instanceof InstancePlayer) && ((DGlobalPlayer) dPlayer).isAnnouncerEnabled()) {
+                if (worlds.isEmpty() || worlds.contains(dPlayer.getPlayer().getWorld().getName())) {
+                    announcer.send(dPlayer.getPlayer());
                 }
             }
         }

--- a/core/src/main/java/de/erethon/dungeonsxl/command/AnnounceCommand.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/command/AnnounceCommand.java
@@ -19,18 +19,17 @@ package de.erethon.dungeonsxl.command;
 import de.erethon.commons.chat.MessageUtil;
 import de.erethon.dungeonsxl.DungeonsXL;
 import de.erethon.dungeonsxl.announcer.Announcer;
+import de.erethon.dungeonsxl.api.player.GlobalPlayer;
+import de.erethon.dungeonsxl.api.player.InstancePlayer;
 import de.erethon.dungeonsxl.config.DMessage;
 import de.erethon.dungeonsxl.player.DGlobalPlayer;
-import de.erethon.dungeonsxl.player.DInstancePlayer;
 import de.erethon.dungeonsxl.player.DPermission;
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 import java.util.List;
 
 /**
- * @author Daniel Saukel
+ * @author Goh Wei Wen
  */
 public class AnnounceCommand extends DCommand {
 
@@ -55,11 +54,10 @@ public class AnnounceCommand extends DCommand {
         }
 
         List<String> worlds = announcer.getWorlds();
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            DGlobalPlayer dPlayer = (DGlobalPlayer) plugin.getPlayerCache().get(player);
-            if (!(dPlayer instanceof DInstancePlayer) && dPlayer.isAnnouncerEnabled()) {
-                if (worlds.isEmpty() || worlds.contains(player.getWorld().getName())) {
-                    announcer.send(player);
+        for (GlobalPlayer dPlayer : plugin.getPlayerCache()) {
+            if (!(dPlayer instanceof InstancePlayer) && ((DGlobalPlayer) dPlayer).isAnnouncerEnabled()) {
+                if (worlds.isEmpty() || worlds.contains(dPlayer.getPlayer().getWorld().getName())) {
+                    announcer.send(dPlayer.getPlayer());
                 }
             }
         }

--- a/core/src/main/java/de/erethon/dungeonsxl/command/AnnounceCommand.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/command/AnnounceCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2012-2020 Frank Baumann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.erethon.dungeonsxl.command;
+
+import de.erethon.commons.chat.MessageUtil;
+import de.erethon.dungeonsxl.DungeonsXL;
+import de.erethon.dungeonsxl.announcer.Announcer;
+import de.erethon.dungeonsxl.config.DMessage;
+import de.erethon.dungeonsxl.player.DGlobalPlayer;
+import de.erethon.dungeonsxl.player.DInstancePlayer;
+import de.erethon.dungeonsxl.player.DPermission;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * @author Daniel Saukel
+ */
+public class AnnounceCommand extends DCommand {
+
+    public AnnounceCommand(DungeonsXL plugin) {
+        super(plugin);
+        setCommand("announce");
+        setMinArgs(1);
+        setMaxArgs(1);
+        setHelp(DMessage.CMD_ANNOUNCE_HELP.getMessage());
+        setPermission(DPermission.ANNOUNCE.getNode());
+        setPlayerCommand(true);
+    }
+
+    @Override
+    public void onExecute(String[] args, CommandSender sender) {
+        String name = args[1];
+        Announcer announcer = plugin.getAnnouncerCache().getByName(name);
+
+        if (announcer == null) {
+            MessageUtil.sendMessage(sender, DMessage.ERROR_NO_SUCH_ANNOUNCER.getMessage(name));
+            return;
+        }
+
+        List<String> worlds = announcer.getWorlds();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            DGlobalPlayer dPlayer = (DGlobalPlayer) plugin.getPlayerCache().get(player);
+            if (!(dPlayer instanceof DInstancePlayer) && dPlayer.isAnnouncerEnabled()) {
+                if (worlds.isEmpty() || worlds.contains(player.getWorld().getName())) {
+                    announcer.send(player);
+                }
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/de/erethon/dungeonsxl/command/DCommandCache.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/command/DCommandCache.java
@@ -29,6 +29,7 @@ public class DCommandCache extends DRECommandCache {
 
     public static final String LABEL = "dungeonsxl";
 
+    public AnnounceCommand announce;
     public BreakCommand breakCmd;
     public ChatCommand chat;
     public ChatSpyCommand chatSpy;
@@ -63,6 +64,7 @@ public class DCommandCache extends DRECommandCache {
     public DCommandCache(DungeonsXL plugin) {
         super(LABEL, plugin);
 
+        announce = new AnnounceCommand(plugin);
         breakCmd = new BreakCommand(plugin);
         chat = new ChatCommand(plugin);
         chatSpy = new ChatSpyCommand(plugin);
@@ -94,6 +96,7 @@ public class DCommandCache extends DRECommandCache {
         test = new TestCommand(plugin);
         uninvite = new UninviteCommand(plugin);
 
+        addCommand(announce);
         addCommand(breakCmd);
         addCommand(create);
         addCommand(delete);

--- a/core/src/main/java/de/erethon/dungeonsxl/config/DMessage.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/config/DMessage.java
@@ -26,6 +26,7 @@ import de.erethon.commons.config.Message;
 public enum DMessage implements Message {
 
     ANNOUNCER_CLICK("announcer.click"),
+    CMD_ANNOUNCE_HELP("cmd.announce.help"),
     CMD_BREAK_BREAK_MODE("cmd.break.breakMode"),
     CMD_BREAK_HELP("cmd.break.help"),
     CMD_BREAK_PROTECTED_MODE("cmd.break.protectedMode"),
@@ -126,6 +127,7 @@ public enum DMessage implements Message {
     ERROR_NO_PROTECTED_BLOCK("error.noProtectedBlock"),
     ERROR_NO_READY_SIGN("error.noReadySign"),
     ERROR_NO_REWARDS_TIME("error.noRewardsTime"),
+    ERROR_NO_SUCH_ANNOUNCER("error.noSuchAnnouncer"),
     ERROR_NO_SUCH_DUNGEON("error.noSuchDungeon"),
     ERROR_NO_SUCH_GROUP("error.noSuchGroup"),
     ERROR_NO_SUCH_MAP("error.noSuchMap"),

--- a/core/src/main/java/de/erethon/dungeonsxl/player/DPermission.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DPermission.java
@@ -32,6 +32,7 @@ import static org.bukkit.permissions.PermissionDefault.*;
 public enum DPermission {
 
     // Main nodes
+    ANNOUNCE("announce", OP),
     BED("bed", OP),
     BREAK("break", OP),
     BYPASS("bypass", OP),

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -1,4 +1,6 @@
-announcer: 
+announce:
+  help: "/dxl announce [name] - Runs an announcement script"
+announcer:
   click: "&4&l=> &6CLICK HERE TO JOIN &4&l<="
 button: 
   accept: "&a[ YES ]"
@@ -141,6 +143,7 @@ error:
   noProtectedBlock: "&4This is not a block protected by DungeonsXL."
   noReadySign: "&4The world &6&v1 &4does not seem to have a ready sign. No game can be started and only lobby dungeon signs will be initialized."
   noRewardsTime: "&4You cannot receive rewards before &6&v1&4."
+  noSuchAnnouncement: "&4This announcement does not exist."
   noSuchDungeon: "&4This dungeon does not exist."
   noSuchGroup: "&4The group &6&v1&4 does not exist."
   noSuchMap: "&4The world &6&v1&4 does not exist."


### PR DESCRIPTION
Adds a `/dxl announce [name]` command that runs an announcement script. Also allows disabling the announcement interval by settings it to <= 0.

This will allow dungeons to be started manually without the need of signs or `/dxl play`.