### PR TITLE
Add resetClassInventoryOnRespawn game rule

### DIFF
--- a/api/src/main/java/de/erethon/dungeonsxl/api/dungeon/GameRule.java
+++ b/api/src/main/java/de/erethon/dungeonsxl/api/dungeon/GameRule.java
@@ -62,6 +62,10 @@ public class GameRule<V> {
      */
     public static final GameRule<Boolean> KEEP_INVENTORY_ON_DEATH = new GameRule<>(Boolean.class, "keepInventoryOnDeath", true);
     /**
+     * Shall players reset their inventory to their chosen class when respawning?
+     */
+    public static final GameRule<Boolean> RESET_CLASS_INVENTORY_ON_RESPAWN = new GameRule<>(Boolean.class, "resetClassInventoryOnRespawn", true);
+    /**
      * The location where the players spawn when they leave the dungeon without succeeding.
      */
     public static final GameRule<String> ESCAPE_LOCATION = new GameRule<>(String.class, "escapeLocation", null);

--- a/core/src/main/java/de/erethon/dungeonsxl/player/DGamePlayer.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DGamePlayer.java
@@ -72,6 +72,7 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
     private Wolf wolf;
     private int wolfRespawnTime = 30;
     private long offlineTime;
+    private boolean resetClassInventoryOnRespawn;
 
     private int initialLives = -1;
     private int lives;
@@ -104,6 +105,8 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
 
         initialLives = rules.getState(GameRule.INITIAL_LIVES);
         lives = initialLives;
+
+        resetClassInventoryOnRespawn = rules.getState(GameRule.RESET_CLASS_INVENTORY_ON_RESPAWN);
 
         Location teleport = world.getLobbyLocation();
         if (teleport == null) {
@@ -532,9 +535,13 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
 
         PlayerUtil.secureTeleport(getPlayer(), respawn);
 
-        // Don't forget Doge!
-        if (wolf != null) {
-            wolf.teleport(getPlayer());
+        if (resetClassInventoryOnRespawn) {
+            setPlayerClass(dClass);
+        } else {
+            // Don't forget Doge!
+            if (wolf != null) {
+                wolf.teleport(getPlayer());
+            }
         }
     }
 
@@ -657,6 +664,10 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
             heal();
             if (getWolf() != null) {
                 getWolf().teleport(respawn);
+            }
+
+            if (rules.getState(GameRule.RESET_CLASS_INVENTORY_ON_RESPAWN)) {
+                setPlayerClass(dClass);
             }
 
         } else if (config.areGlobalDeathMessagesDisabled()) {

--- a/core/src/main/java/de/erethon/dungeonsxl/player/DPlayerListener.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DPlayerListener.java
@@ -499,8 +499,11 @@ public class DPlayerListener implements Listener {
                 respawn = group.getGameWorld().getStartLocation(group);
             }
 
+            boolean shouldResetInventory = gamePlayer.getGameWorld().getDungeon().getRules().getState(GameRule.RESET_CLASS_INVENTORY_ON_RESPAWN);
+
             // Because some plugins set another respawn point, DXL teleports a few ticks later.
-            new RespawnTask(player, respawn).runTaskLater(plugin, 10L);
+            event.setRespawnLocation(respawn);
+            new RespawnTask(player, gamePlayer, respawn, shouldResetInventory).runTaskLater(plugin, 10L);
 
             // Don't forget Doge!
             if (gamePlayer.getWolf() != null) {

--- a/core/src/main/java/de/erethon/dungeonsxl/player/RespawnTask.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/RespawnTask.java
@@ -17,6 +17,7 @@
 package de.erethon.dungeonsxl.player;
 
 import de.erethon.commons.player.PlayerUtil;
+import de.erethon.dungeonsxl.api.player.GamePlayer;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -27,11 +28,15 @@ import org.bukkit.scheduler.BukkitRunnable;
 public class RespawnTask extends BukkitRunnable {
 
     private Player player;
+    private GamePlayer dPlayer;
     private Location location;
+    private boolean resetClassInventory;
 
-    public RespawnTask(Player player, Location location) {
+    public RespawnTask(Player player, GamePlayer dPlayer, Location location, boolean resetClassInventory) {
         this.location = location;
         this.player = player;
+        this.dPlayer = dPlayer;
+        this.resetClassInventory = resetClassInventory;
     }
 
     @Override
@@ -41,6 +46,9 @@ public class RespawnTask extends BukkitRunnable {
         }
         if (player.getWorld() != location.getWorld() || player.getLocation().distance(location) > 2) {
             PlayerUtil.secureTeleport(player, location);
+        }
+        if (resetClassInventory) {
+            dPlayer.setPlayerClass(dPlayer.getPlayerClass());
         }
     }
 


### PR DESCRIPTION
This new game rule will reset the player's inventory to the default class inventory. Useful for kit PvP.