### PR TITLE
Fixed edit permissions getting added to the wrong world

### DIFF
--- a/core/src/main/java/de/erethon/dungeonsxl/player/DEditPlayer.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DEditPlayer.java
@@ -63,7 +63,7 @@ public class DEditPlayer extends DInstancePlayer implements EditPlayer {
         // Permission bridge
         if (plugin.getPermissionProvider() != null) {
             for (String permission : plugin.getMainConfig().getEditPermissions()) {
-                plugin.getPermissionProvider().playerAddTransient(world.getName(), player, permission);
+                plugin.getPermissionProvider().playerAddTransient(getWorld().getName(), player, permission);
             }
         }
     }


### PR DESCRIPTION
Bisher wurden Permissions einer Welt mit dem Dungeon-Namen ("Test") hinzugefügt und einer Welt mit dem EditWorld-Namen ("DXL_Edit_0") wieder entfernt. Funktioniert natürlich nicht, LuckPerms ist unschuldig. 
``world`` ist wohl der Dungeon-Name, ``getWorld()`` der tatsächliche Name der Edit-World. Ob das tatsächlich so sein sollte (ist zumindest minimal verwirrend) kann ich nicht bewerten, aber zumindest die Permissions gehen nun wieder. 
Dieser PR fixt das. 
