### PR TITLE
Properly initialize dungeon in DGame constructor

### DIFF
--- a/core/src/main/java/de/erethon/dungeonsxl/dungeon/DGame.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/dungeon/DGame.java
@@ -64,7 +64,8 @@ public class DGame implements Game {
         this.plugin = plugin;
         plugin.getGameCache().add(this);
 
-        this.dungeon = dungeon;
+        setDungeon(dungeon);
+
         if (this.dungeon == null) {
             throw new IllegalStateException("Game initialized without dungeon");
         }


### PR DESCRIPTION
Fixes `unplayedFloors` being empty when starting a new game