### PR TITLE
Update PlaceholderAPI dependency, and make placeholders persist. 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.9</version>
+            <version>2.10.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/de/erethon/dungeonsxl/util/PlaceholderUtil.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/util/PlaceholderUtil.java
@@ -21,7 +21,7 @@ import de.erethon.dungeonsxl.api.dungeon.Game;
 import de.erethon.dungeonsxl.api.player.PlayerGroup;
 import de.erethon.dungeonsxl.api.world.GameWorld;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 
 /**
  * @author Daniel Saukel
@@ -67,7 +67,7 @@ public class PlaceholderUtil extends PlaceholderExpansion {
         if (player == null) {
             return "";
         }
-        PlayerGroup group = plugin.getPlayerGroup(player);
+        PlayerGroup group = plugin.getPlayerGroup(player.getPlayer());
 
         switch (identifier) {
             case "group_members":

--- a/core/src/main/java/de/erethon/dungeonsxl/util/PlaceholderUtil.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/util/PlaceholderUtil.java
@@ -56,9 +56,14 @@ public class PlaceholderUtil extends PlaceholderExpansion {
     public String getVersion() {
         return plugin.getDescription().getVersion();
     }
+    
+    @Override
+    public boolean persist() {
+        return true;
+    }
 
     @Override
-    public String onPlaceholderRequest(Player player, String identifier) {
+    public String onRequest(OfflinePlayer player, String identifier) {
         if (player == null) {
             return "";
         }


### PR DESCRIPTION
Previously, if you used /papi reload, the DXL expansion would completely break, as the placeholders didn't persist.  This is quite a simple change to fix the issue! 