### PR TITLE
Added support for multiverse inventories

### DIFF
--- a/core/src/main/java/de/erethon/dungeonsxl/player/DGamePlayer.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DGamePlayer.java
@@ -105,12 +105,17 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
             initDGroupTag();
         }
 
+        String originalWorld = player.getWorld().getName();
+        addMultiversePerm(originalWorld);
+
         Location teleport = world.getLobbyLocation();
         if (teleport == null) {
             player.teleport(world.getWorld().getSpawnLocation());
         } else {
             player.teleport(teleport);
         }
+
+        removeMultiversePerm(originalWorld);
 
         if (!((DGameWorld) world).hasReadySign()) {
             MessageUtil.sendMessage(player, DMessage.ERROR_NO_READY_SIGN.getMessage(world.getName()));
@@ -380,7 +385,10 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
         delete();
 
         if (player.isOnline()) {
+            String gameWorld = getGameWorld().getWorld().getName();
+            addMultiversePerm(gameWorld);
             reset(finished);
+            removeMultiversePerm(gameWorld);
         }
 
         // Permission bridge
@@ -589,6 +597,7 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
                 plugin.getPermissionProvider().playerAddTransient(getGame().getWorld().getWorld().getName(), player, permission);
             }
         }
+
     }
 
     /**
@@ -807,5 +816,18 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
         plugin.log("Player " + this + " was expected to be online but is offline.", player, Player::isOnline);
         DistanceTrigger.triggerAllInDistance(player, (DGameWorld) getGameWorld());
     }
+
+    // Add permission for by passing multiverse inventories when entering or leaving a dungeon
+    private void addMultiversePerm(String world){
+        if (plugin.getPermissionProvider() != null)
+            plugin.getPermissionProvider().playerAddTransient(world, player, "mvinv.bypass.*");
+    }
+
+    // Remove permission for by passing multiverse inventories when entering or leaving a dungeon
+    private void removeMultiversePerm(String world){
+        if (plugin.getPermissionProvider() != null)
+            plugin.getPermissionProvider().playerRemoveTransient(world, player, "mvinv.bypass.*");
+    }
+
 
 }

--- a/core/src/main/java/de/erethon/dungeonsxl/player/DGamePlayer.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DGamePlayer.java
@@ -105,17 +105,12 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
             initDGroupTag();
         }
 
-        String originalWorld = player.getWorld().getName();
-        addMultiversePerm(originalWorld);
-
         Location teleport = world.getLobbyLocation();
         if (teleport == null) {
             player.teleport(world.getWorld().getSpawnLocation());
         } else {
             player.teleport(teleport);
         }
-
-        removeMultiversePerm(originalWorld);
 
         if (!((DGameWorld) world).hasReadySign()) {
             MessageUtil.sendMessage(player, DMessage.ERROR_NO_READY_SIGN.getMessage(world.getName()));
@@ -384,12 +379,8 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
         GameRuleContainer rules = getGame().getRules();
         delete();
 
-        if (player.isOnline()) {
-            String gameWorld = getGameWorld().getWorld().getName();
-            addMultiversePerm(gameWorld);
+        if (player.isOnline())
             reset(finished);
-            removeMultiversePerm(gameWorld);
-        }
 
         // Permission bridge
         if (plugin.getPermissionProvider() != null) {
@@ -815,18 +806,6 @@ public class DGamePlayer extends DInstancePlayer implements GamePlayer {
 
         plugin.log("Player " + this + " was expected to be online but is offline.", player, Player::isOnline);
         DistanceTrigger.triggerAllInDistance(player, (DGameWorld) getGameWorld());
-    }
-
-    // Add permission for by passing multiverse inventories when entering or leaving a dungeon
-    private void addMultiversePerm(String world){
-        if (plugin.getPermissionProvider() != null)
-            plugin.getPermissionProvider().playerAddTransient(world, player, "mvinv.bypass.*");
-    }
-
-    // Remove permission for by passing multiverse inventories when entering or leaving a dungeon
-    private void removeMultiversePerm(String world){
-        if (plugin.getPermissionProvider() != null)
-            plugin.getPermissionProvider().playerRemoveTransient(world, player, "mvinv.bypass.*");
     }
 
 

--- a/core/src/main/java/de/erethon/dungeonsxl/player/DInstancePlayer.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/player/DInstancePlayer.java
@@ -24,6 +24,8 @@ import de.erethon.dungeonsxl.api.world.InstanceWorld;
 import de.erethon.dungeonsxl.config.MainConfig;
 import de.erethon.dungeonsxl.util.AttributeUtil;
 import de.erethon.dungeonsxl.util.ParsingUtil;
+
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
@@ -42,6 +44,9 @@ public abstract class DInstancePlayer extends DGlobalPlayer implements InstanceP
         super(plugin, player, false);
 
         config = plugin.getMainConfig();
+
+        String gameWorld = world.getWorld().getName();
+        this.addMultiversePerm(gameWorld);
 
         instanceWorld = world;
         getData().savePlayerState(player);
@@ -135,5 +140,26 @@ public abstract class DInstancePlayer extends DGlobalPlayer implements InstanceP
      * Repeating checks for the player.
      */
     public abstract void update();
+
+    @Override
+    public void reset(Location tpLoc, boolean keepInventory){
+        String tpWorld = tpLoc.getWorld().getName();
+        addMultiversePerm(tpWorld);
+        super.reset(tpLoc, keepInventory);
+        removeMultiversePerm(tpWorld);
+        removeMultiversePerm(this.getWorld().getName());
+    }
+
+    // Add permission for by passing multiverse inventories when entering or leaving a dungeon
+    private void addMultiversePerm(String world){
+        if (plugin.getPermissionProvider() != null)
+            plugin.getPermissionProvider().playerAddTransient(world, player, "mvinv.bypass.*");
+    }
+
+    // Remove permission for by passing multiverse inventories when entering or leaving a dungeon
+    private void removeMultiversePerm(String world){
+        if (plugin.getPermissionProvider() != null)
+            plugin.getPermissionProvider().playerRemoveTransient(world, player, "mvinv.bypass.*");
+    }
 
 }

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ authors: [Frank Baumann, Milan Albrecht, Tobias Schmitz, Daniel Saukel]
 description: ${project.parent.description}
 website: ${project.parent.url}
 depend: [ItemsXL]
-softdepend: [CommandsXL, ItemsXL, Vault, Citizens, CustomMobs, InsaneMobs, MythicMobs, HolographicDisplays, LWC, PlaceholderAPI, Parties]
+softdepend: [CommandsXL, ItemsXL, Vault, Citizens, CustomMobs, InsaneMobs, MythicMobs, HolographicDisplays, LWC, PlaceholderAPI, Parties, Multiverse-Inventories]
 commands:
   dungeonsxl:
     description: Reference command for DungeonsXL.


### PR DESCRIPTION
Multiverse Inventories fights with this plugin when entering a dungeon world so I added a few lines that will give the player a temp transient permission that Multiverse uses when entering and exiting dungeons so their inventories don't get affected by it. Have tested with LuckPerms and seems to work perfectly. Should give full remove any issues between Multiverse Inventories and Dungeons XL. (Though maybe mentioning in the wiki under compabilty that you must turn on said permission in the Multiverse Inventories config for this to do anything).