### PR TITLE
Port to Paper 1.21.11 / Java 21 / XLib 7.0

### DIFF
--- a/addon/core/pom.xml
+++ b/addon/core/pom.xml
@@ -24,8 +24,8 @@
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigotVersion.latest}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/addon/core/src/main/java/de/erethon/dungeonsxxl/DungeonsXXL.java
+++ b/addon/core/src/main/java/de/erethon/dungeonsxxl/DungeonsXXL.java
@@ -15,33 +15,42 @@ import de.erethon.dungeonsxl.api.trigger.Trigger;
 import de.erethon.dungeonsxxl.requirement.*;
 import de.erethon.dungeonsxxl.sign.*;
 import de.erethon.dungeonsxxl.util.GlowUtil;
-import de.erethon.xlib.compatibility.Internals;
+import de.erethon.xlib.XLib;
+import de.erethon.xlib.compatibility.Version;
 import de.erethon.xlib.plugin.PluginInit;
-import de.erethon.xlib.plugin.DREPluginSettings;
+import de.erethon.xlib.plugin.PluginMeta;
+import de.erethon.xlib.spiget.comparator.VersionComparator;
 import de.erethon.xlib.util.Registry;
+import org.bukkit.plugin.java.JavaPlugin;
 
 /**
  * @author Daniel Saukel
  */
-public class DungeonsXXL extends PluginInit implements DungeonModule {
+public class DungeonsXXL extends JavaPlugin implements DungeonModule {
+
+    // 1.21.11 port: XLib 7.0 replaced DREPluginSettings+Internals with PluginMeta.
+    // PluginInit is now a helper, not a base class — we extend JavaPlugin directly
+    // and hold a PluginInit instance for MessageHandler/resource-save helpers.
+    public static final PluginMeta META = new PluginMeta.Builder("DungeonsXXL")
+            .minVersion(Version.MC1_21_11)
+            .paperState(PluginMeta.State.SUPPORTED)
+            .spigotState(PluginMeta.State.SUPPORTED)
+            .spigotMCResourceId(-1)
+            .versionComparator(VersionComparator.SEM_VER_SNAPSHOT)
+            .build();
 
     private static DungeonsXXL instance;
     private DungeonsXL dxl;
     private GlowUtil glowUtil;
-
-    public DungeonsXXL() {
-        settings = DREPluginSettings.builder()
-                .internals(Internals.v1_16_R3)
-                .metrics(false)
-                .spigotMCResourceId(-1)
-                .build();
-    }
+    private PluginInit init;
 
     @Override
     public void onEnable() {
         instance = this;
         dxl = DungeonsXL.getInstance();
+        init = new PluginInit(this, XLib.getInstance(), META);
         glowUtil = new GlowUtil(this);
+        dxl.registerModule(this);
     }
 
     /**
@@ -69,6 +78,10 @@ public class DungeonsXXL extends PluginInit implements DungeonModule {
      */
     public GlowUtil getGlowUtil() {
         return glowUtil;
+    }
+
+    public PluginInit getInitializer() {
+        return init;
     }
 
     @Override

--- a/addon/core/src/main/java/de/erethon/dungeonsxxl/util/FireworkUtil.java
+++ b/addon/core/src/main/java/de/erethon/dungeonsxxl/util/FireworkUtil.java
@@ -31,7 +31,8 @@ public class FireworkUtil {
      * @return the Firework
      */
     public static Firework spawnRandom(Location location) {
-        Firework firework = (Firework) location.getWorld().spawnEntity(location, EntityType.FIREWORK);
+        // 1.21 port: EntityType.FIREWORK -> FIREWORK_ROCKET
+        Firework firework = (Firework) location.getWorld().spawnEntity(location, EntityType.FIREWORK_ROCKET);
         FireworkMeta meta = firework.getFireworkMeta();
         Random r = new Random();
         int rt = r.nextInt(4) + 1;

--- a/addon/core/src/main/java/de/erethon/dungeonsxxl/util/GlowUtil.java
+++ b/addon/core/src/main/java/de/erethon/dungeonsxxl/util/GlowUtil.java
@@ -2,6 +2,20 @@
  * Copyright (C) 2020-2026 Daniel Saukel
  *
  * All rights reserved.
+ *
+ * --- 1.21.11 PORT NOTE ---
+ * The original class contained packet-level, per-player variants of the glow
+ * effect that depended on net.minecraft.server.v1_16_R3.* (deleted in MC 1.17)
+ * and CraftBukkit v1_16_R3 relocations (deleted in MC 1.20.5).
+ *
+ * Those methods (addBlockGlow(Block, ChatColor, Player...), per-player rainbow
+ * variant, addGlow(NMS.Entity, ...), addRainbowGlow(NMS.Entity, ...),
+ * removeGlow(NMS.Entity)) are REMOVED. On 1.21.11 there is no stable Bukkit
+ * API for per-player fake entities; implementing them requires Mojang-mapped
+ * NMS (unstable between minor versions) or ProtocolLib/PacketEvents.
+ *
+ * The world-visible variants are preserved and use only the public Bukkit
+ * API. Callers that need per-player glow must re-implement via ProtocolLib.
  */
 package de.erethon.dungeonsxxl.util;
 
@@ -9,17 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
-import net.minecraft.server.v1_16_R3.EntityShulker;
-import net.minecraft.server.v1_16_R3.EntityTypes;
-import net.minecraft.server.v1_16_R3.Packet;
-import net.minecraft.server.v1_16_R3.PacketPlayOutEntityDestroy;
-import net.minecraft.server.v1_16_R3.PacketPlayOutSpawnEntityLiving;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Shulker;
 import org.bukkit.event.EventHandler;
@@ -41,7 +48,6 @@ public class GlowUtil implements Listener {
 
     private Map<ChatColor, Team> teams = new HashMap<>();
     private GlowData<org.bukkit.entity.Entity> glowingBlocks = new GlowData<>();
-    private Map<Player, GlowData<net.minecraft.server.v1_16_R3.Entity>> playerGlows = new HashMap<>();
     private GlowRunnable runnable = new GlowRunnable();
 
     public GlowUtil(Plugin plugin) {
@@ -61,13 +67,6 @@ public class GlowUtil implements Listener {
         return teams.get(color);
     }
 
-    /**
-     * Adds a colored glow effect to the block that is visible to all players.
-     *
-     * @param block the block
-     * @param color the glow color
-     * @return the spawned entity that provides the glow effect
-     */
     public org.bukkit.entity.Entity addBlockGlow(Block block, ChatColor color) {
         Shulker entity = block.getWorld().spawn(new Location(block.getWorld(), block.getX() + .5, block.getY(), block.getZ() + .5), Shulker.class);
         entity.setAI(false);
@@ -78,46 +77,10 @@ public class GlowUtil implements Listener {
         return entity;
     }
 
-    /**
-     * Adds a packet-level colored glow effect to the block that is only visible to certain players.
-     *
-     * @param block   the block
-     * @param color   the glow color
-     * @param players the players who can see the effect
-     */
-    public void addBlockGlow(Block block, ChatColor color, Player... players) {
-        EntityShulker entity = new EntityShulker(EntityTypes.SHULKER, ((CraftWorld) block.getWorld()).getHandle());
-        entity.setLocation(block.getX() + .5, block.getY(), block.getZ() + .5, 0, 0);
-        entity.setFlag(6, true);
-        entity.setInvisible(true);
-        for (Player player : players) {
-            sendPacket(player, new PacketPlayOutSpawnEntityLiving(entity));
-            if (playerGlows.get(player) == null) {
-                playerGlows.put(player, new GlowData<>());
-            }
-            playerGlows.get(player).put(block, entity);
-        }
-    }
-
-    /**
-     * Adds a rainbow colored glow effect to the block that is visible to all players.
-     *
-     * @param block the block
-     * @return the spawned entity that provides the glow effect
-     */
     public org.bukkit.entity.Entity addRainbowBlockGlow(Block block) {
         return addRainbowBlockGlow(block, (Long) null);
     }
 
-    /**
-     * Adds a rainbow colored glow effect to the block that is visible to all players.
-     * <p>
-     * The task is cancelled automatically when the entity dies.
-     *
-     * @param block      the block
-     * @param cancelTime the time in milliseconds until the glow effect shall end; null = forever
-     * @return the spawned entity that provides the glow effect
-     */
     public org.bukkit.entity.Entity addRainbowBlockGlow(Block block, Long cancelTime) {
         Shulker entity = block.getWorld().spawn(new Location(block.getWorld(), block.getX() + .5, block.getY(), block.getZ() + .5), Shulker.class);
         entity.setAI(false);
@@ -128,47 +91,6 @@ public class GlowUtil implements Listener {
         return entity;
     }
 
-    /**
-     * Adds a packet-level rainbow colored glow effect to the block that is only visible to certain players.
-     * <p>
-     * Returns the repeating task that handles color changes.
-     *
-     * @param block   the block
-     * @param players
-     */
-    public void addRainbowBlockGlow(Block block, Player... players) {
-        addRainbowBlockGlow(block, null, players);
-    }
-
-    /**
-     * Adds a packet-level rainbow colored glow effect to the block that is only visible to certain players.
-     * <p>
-     * Returns the repeating task that handles color changes.
-     *
-     * @param block      the block
-     * @param cancelTime the time in milliseconds until the glow effect shall end; null = forever
-     * @param players
-     */
-    public void addRainbowBlockGlow(Block block, Long cancelTime, Player... players) {
-        EntityShulker entity = new EntityShulker(EntityTypes.SHULKER, ((CraftWorld) block.getWorld()).getHandle());
-        entity.setLocation(block.getX() + .5, block.getY(), block.getZ() + .5, 0, 0);
-        entity.setFlag(6, true);
-        entity.setInvisible(true);
-        for (Player player : players) {
-            sendPacket(player, new PacketPlayOutSpawnEntityLiving(entity));
-            if (playerGlows.get(player) == null) {
-                playerGlows.put(player, new GlowData<>());
-            }
-            playerGlows.get(player).put(block, entity);
-        }
-        addRainbowGlow(entity, cancelTime);
-    }
-
-    /**
-     * Removes the glow effect from a glowing block.
-     *
-     * @param block the block
-     */
     public void removeBlockGlow(Block block) {
         org.bukkit.entity.Entity bukkitEntity = glowingBlocks.get(block);
         if (bukkitEntity != null) {
@@ -176,110 +98,30 @@ public class GlowUtil implements Listener {
             glowingBlocks.remove(block);
             runnable.removeEntity(bukkitEntity);
         }
-
-        for (Entry<Player, GlowData<net.minecraft.server.v1_16_R3.Entity>> entry : playerGlows.entrySet()) {
-            net.minecraft.server.v1_16_R3.Entity nmsEntity = entry.getValue().get(block);
-            if (nmsEntity != null) {
-                sendPacket(entry.getKey(), new PacketPlayOutEntityDestroy(nmsEntity.getId()));
-                runnable.removeEntity(nmsEntity);
-            }
-        }
     }
 
-    /**
-     * Adds a colored glow effect to an entity and handles its scoreboard team membership.
-     *
-     * @param entity a Bukkit Entity
-     * @param color  the glow color
-     */
     public void addGlow(org.bukkit.entity.Entity entity, ChatColor color) {
         getTeam(color).addEntry(asEntry(entity));
         entity.setGlowing(true);
     }
 
-    /**
-     * Adds a colored glow effect to an entity and handles its scoreboard team membership.
-     *
-     * @param entity an NMS Entity
-     * @param color  the glow color
-     */
-    public void addGlow(net.minecraft.server.v1_16_R3.Entity entity, ChatColor color) {
-        getTeam(color).addEntry(asEntry(entity));
-        entity.setFlag(6, true);
-    }
-
-    /**
-     * Adds a changing glow effect to an entity.
-     *
-     * @param entity an NMS Entity
-     */
     public void addRainbowGlow(org.bukkit.entity.Entity entity) {
         addRainbowGlow(entity, null);
     }
 
-    /**
-     * Adds a changing glow effect to an entity.
-     *
-     * @param entity     an NMS Entity
-     * @param cancelTime the time in milliseconds until the glow effect shall end; null = forever
-     */
     public void addRainbowGlow(org.bukkit.entity.Entity entity, Long cancelTime) {
         entity.setGlowing(true);
         runnable.addEntity(entity, cancelTime != null ? System.currentTimeMillis() + cancelTime : null);
     }
 
-    /**
-     * Adds a changing glow effect to an entity.
-     *
-     * @param entity an NMS Entity
-     */
-    public void addRainbowGlow(net.minecraft.server.v1_16_R3.Entity entity) {
-        addRainbowGlow(entity, null);
-    }
-
-    /**
-     * Adds a changing glow effect to an entity.
-     *
-     * @param entity     an NMS Entity
-     * @param cancelTime the time in milliseconds until the glow effect shall end; null = forever
-     */
-    public void addRainbowGlow(net.minecraft.server.v1_16_R3.Entity entity, Long cancelTime) {
-        entity.setFlag(6, true);
-        runnable.addEntity(entity, cancelTime != null ? System.currentTimeMillis() + cancelTime : null);
-    }
-
-    /**
-     * Removes the glow effect from an entity and handles its scoreboard team membership.
-     *
-     * @param entity a Bukkit Entity
-     */
     public void removeGlow(org.bukkit.entity.Entity entity) {
         entity.setGlowing(false);
         teams.values().forEach(t -> t.removeEntry(asEntry(entity)));
         runnable.removeEntity(entity);
     }
 
-    /**
-     * Removes the glow effect from an entity and handles its scoreboard team membership.
-     *
-     * @param entity an NMS Entity
-     */
-    public void removeGlow(net.minecraft.server.v1_16_R3.Entity entity) {
-        entity.setFlag(6, false);
-        teams.values().forEach(t -> t.removeEntry(asEntry(entity)));
-        runnable.removeEntity(entity);
-    }
-
     private static String asEntry(org.bukkit.entity.Entity entity) {
         return entity instanceof Player ? entity.getName() : entity.getUniqueId().toString();
-    }
-
-    private static String asEntry(net.minecraft.server.v1_16_R3.Entity entity) {
-        return entity instanceof Player ? entity.getName() : entity.getUniqueID().toString();
-    }
-
-    private static void sendPacket(Player player, Packet<?> packet) {
-        ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
     }
 
     @EventHandler
@@ -289,7 +131,7 @@ public class GlowUtil implements Listener {
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        playerGlows.remove(event.getPlayer());
+        // retained for API compatibility; per-player packet maps have been removed
     }
 
     private class GlowRunnable extends BukkitRunnable {
@@ -311,8 +153,6 @@ public class GlowUtil implements Listener {
             for (Entry<Object, Long> entry : entities.entrySet().toArray(new Entry[entities.size()])) {
                 if (entry.getKey() instanceof org.bukkit.entity.Entity) {
                     run((org.bukkit.entity.Entity) entry.getKey(), entry.getValue());
-                } else if (entry.getKey() instanceof net.minecraft.server.v1_16_R3.Entity) {
-                    run((net.minecraft.server.v1_16_R3.Entity) entry.getKey(), entry.getValue());
                 }
             }
         }
@@ -326,23 +166,6 @@ public class GlowUtil implements Listener {
                     entity.setGlowing(false);
                 } else {
                     entity.remove();
-                }
-                return;
-            }
-            getTeam(color).addEntry(asEntry(entity));
-        }
-
-        private void run(net.minecraft.server.v1_16_R3.Entity entity, Long cancelTime) {
-            getTeam(color).removeEntry(asEntry(entity));
-            if (cancelTime != null && System.currentTimeMillis() >= cancelTime) {
-                entities.remove(entity);
-                for (Entry<Player, GlowData<net.minecraft.server.v1_16_R3.Entity>> entry : playerGlows.entrySet()) {
-                    if (!entry.getValue().glowingBlocks.containsValue(entity)) {
-                        continue;
-                    }
-                    Player player = entry.getKey();
-                    sendPacket(player, new PacketPlayOutEntityDestroy(entity.getId()));
-                    entry.getValue().remove(entity);
                 }
                 return;
             }

--- a/addon/core/src/main/resources/plugin.yml
+++ b/addon/core/src/main/resources/plugin.yml
@@ -5,3 +5,4 @@ author: Daniel Saukel
 description: ${project.description}
 website: ${project.url}
 depend: [DungeonsXL]
+api-version: "1.21"

--- a/core/src/main/java/de/erethon/dungeonsxl/util/AttributeUtil.java
+++ b/core/src/main/java/de/erethon/dungeonsxl/util/AttributeUtil.java
@@ -30,7 +30,8 @@ import org.bukkit.entity.Player;
 public class AttributeUtil {
 
     public static final Attribute ATTACK_DAMAGE = Attribute.valueOf(Version.isAtLeast(Version.MC1_21_2) ? "ATTACK_DAMAGE" : "GENERIC_ATTACK_DAMAGE");
-    public static final Attribute MAX_HEALTH = Attribute.valueOf(Version.isAtLeast(Version.MC1_21_2) ? "MAX_HEALTH" : "GENERIC_MOVEMENT_SPEED");
+    // 1.21 port: fixed copy-paste bug (was "GENERIC_MOVEMENT_SPEED" for MAX_HEALTH fallback)
+    public static final Attribute MAX_HEALTH = Attribute.valueOf(Version.isAtLeast(Version.MC1_21_2) ? "MAX_HEALTH" : "GENERIC_MAX_HEALTH");
     public static final Attribute MOVEMENT_SPEED = Attribute.valueOf(Version.isAtLeast(Version.MC1_21_2) ? "MOVEMENT_SPEED" : "GENERIC_MOVEMENT_SPEED");
 
     private static final Map<Attribute, Double> DEFAULT_PLAYER_VALUES = ImmutableMap.of(
@@ -49,8 +50,10 @@ public class AttributeUtil {
         if (Version.isAtLeast(Version.MC1_21_2)) {
             attribute = Registry.ATTRIBUTE.match(key);
             if (attribute == null) {
-                // Compatibility upon Minecraft updates
-                attribute = Registry.ATTRIBUTE.match(key.replace("GENERIC_", key));
+                // Compatibility upon Minecraft updates: strip legacy GENERIC_ prefix
+                // 1.21 port: replace() called with wrong 2nd arg (was the whole key);
+                // must be the replacement string, i.e. empty to drop the prefix.
+                attribute = Registry.ATTRIBUTE.match(key.replace("GENERIC_", ""));
             }
         } else {
             try {

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -10,4 +10,4 @@ commands:
   dungeonsxl:
     description: Reference command for DungeonsXL.
     aliases: [dxl,dungeon]
-api-version: 1.13
+api-version: "1.21"

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
     <properties>
         <buildNo></buildNo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <spigotVersion.latest>26.1-R0.1-SNAPSHOT</spigotVersion.latest>
         <dependencyVersion.xlib>7.0-SNAPSHOT</dependencyVersion.xlib>
     </properties>


### PR DESCRIPTION
Ports DungeonsXL and the DungeonsXXL addon to Paper 1.21.11 against XLib 7.0-SNAPSHOT. Tested cleanly on Paper 1.21.11-130 (Java 21).

The bundled `PORT_1_21_11.patch` was a useful skeleton but not buildable — three things slipped through (`addon/core/pom.xml` still on Spigot 1.16.5, the entire `DungeonsXXL.java` bootstrap on the gone XLib 6.x API, and `Internals.UNSUPPORTED` referencing a non-existent constant). Also picked up two real `AttributeUtil` bugs that are independent of the port.

## What worked from the patch as-is

- Java 1.8 → 21 (with `maven.compiler.release=21`)
- `api-version: "1.21"` in both plugin.yml files
- `EntityType.FIREWORK` → `FIREWORK_ROCKET` in `FireworkUtil` (1.20.5 rename)
- NMS cleanup in `GlowUtil` — all `net.minecraft.server.v1_16_R3.*` imports removed, per-player packet methods removed (port notes already document this would need ProtocolLib for 1.21)

## Two `AttributeUtil` bugs

1. `MAX_HEALTH` fallback for MC < 1.21.2 was `"GENERIC_MOVEMENT_SPEED"` — copy-paste typo. Should be `"GENERIC_MAX_HEALTH"`. Probably went unnoticed since the fallback path doesn't fire on 1.21.2+.

2. `key.replace("GENERIC_", key)` — the second arg is the replacement, not the original key. Would have turned `"GENERIC_ATTACK_DAMAGE"` into `"ATTACK_DAMAGEATTACK_DAMAGE"`. Should be `key.replace("GENERIC_", "")`.

Both fixes are already in the port skeleton and got picked up here.

## What I had to add

### `addon/core/pom.xml`

Was still pinning `spigot:1.16.5-R0.1-SNAPSHOT` as the only dependency. That's why `EntityType.FIREWORK_ROCKET` wouldn't resolve at compile time — the compiler was hitting the old 1.16 enum transitively. Replaced with `spigot-api ${spigotVersion.latest}` (same version the core uses).

### `DungeonsXXL.java` rewrite

The entire bootstrap was built against XLib 6.x:

```java
// before
public class DungeonsXXL extends PluginInit implements DungeonModule {
    public DungeonsXXL() {
        settings = DREPluginSettings.builder()
                .internals(Internals.UNSUPPORTED)   // doesn't exist in 7.0
                .metrics(false)
                .spigotMCResourceId(-1)
                .build();
    }
}
```

In XLib 7.0 `Internals` and `DREPluginSettings` are gone, and `PluginInit` is no longer a base class — it's a helper taking `(JavaPlugin, XLib, PluginMeta)`. Rewrote the addon to mirror the core bootstrap pattern:

```java
public class DungeonsXXL extends JavaPlugin implements DungeonModule {

    public static final PluginMeta META = new PluginMeta.Builder("DungeonsXXL")
            .minVersion(Version.MC1_21_11)
            .paperState(PluginMeta.State.SUPPORTED)
            .spigotState(PluginMeta.State.SUPPORTED)
            .spigotMCResourceId(-1)
            .versionComparator(VersionComparator.SEM_VER_SNAPSHOT)
            .build();

    @Override
    public void onEnable() {
        instance = this;
        dxl = DungeonsXL.getInstance();
        init = new PluginInit(this, XLib.getInstance(), META);
        glowUtil = new GlowUtil(this);
        dxl.registerModule(this);
    }
}
```

## Heads-up on module registration order

`DungeonsXXL.onEnable()` calls `dxl.registerModule(this)` **after** DungeonsXL has already finished its `init()` iteration over all registered modules (because `depend: [DungeonsXL]` forces Paper to enable the addon later). Consequence: the addon signs (`FIREWORK`, `GLOWINGBLOCK`, `INTERACTWALL`, `PARTICLE`) and the `feeItems` requirement only get registered after `/dxl reload`, not on initial startup.

I didn't fix this in the PR because the clean solution is moving the bootstrap to `onLoad()` in both plugins, which is a deeper refactor on the core side. Worth tracking as a follow-up. In the pre-7.0 codebase I assume `PluginInit.onEnable()` handled this somehow automatically — if so, the contract changed in 7.0.

## Test

Fresh Paper 1.21.11-130 server, three plugins in `plugins/`:

```
[XLib-Runtime] Enabling XLib-Runtime v7.0-SNAPSHOT
[DungeonsXL]   Enabling DungeonsXL v0.19-SNAPSHOT
[DungeonsXXL]  Enabling DungeonsXXL v0.0.1-SNAPSHOT
Done (28.793s)!
```

No stacktraces, no `NoClassDefFoundError`, no `VerifyError`. Paper's plugin remapper handles both JARs cleanly. `.raw` template world initializes correctly.

One small observation: a single `[ERROR] No key layers in MapLike[{}]` line during initial world setup. Server proceeds normally afterwards, no functional impact I could see — likely a side-effect of the datapack registry changes in 1.21. Couldn't immediately locate the source — happy to dig further if you can point me to where the dungeon template world gets created.

## Out of scope / not in this PR

- **CaliburnAPI/XLib changes:** I had to patch `VanillaMob.java` (added a `BUKKIT_NAME_RENAMES` map for the 18 EntityType renames + silenced the static-init warning prints) and `VanillaItem.java` (silenced the warnings) to get rid of ~370 lines of `[WARNING]` log spam per startup. Those changes belong in a separate PR against `DRE2N/CaliburnAPI` — happy to open it if useful. The runtime ran cleanly with them, and they don't affect this DungeonsXL diff.
- **`paperState(NOT_SUPPORTED)`** in the core's `META` — left as is, since that's a vendor decision.

## Build

Built with Java 21 + Maven. Standard `mvn clean package` from the repo root.

Tested on Paper `1.21.11-130-c5a2736`, OpenJDK 21.0.10.